### PR TITLE
refactor: use JS SDK to query the API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "stepfunction-visualizer",
       "version": "0.0.1",
       "dependencies": {
+        "@aws-sdk/client-sfn": "^3.47.0",
         "@types/mermaid": "^8.2.7",
         "mermaid": "^8.13.9"
       },
@@ -26,6 +27,836 @@
         "svelte-preprocess": "^4.9.4",
         "tslib": "^2.3.1",
         "typescript": "^4.4.3"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.47.0.tgz",
+      "integrity": "sha512-6sxt11dVaJT8CzfVsGCV3h2R0LO12fvXsvCZsMsPGtivb4ZgoFK+PO3hs+9xuA3zjMUC7mb6LE2RM8EXKBDjDw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.47.0.tgz",
+      "integrity": "sha512-AIcEpLMQof5eJuOpo6Rat5RGpkRCLM3WS3O3hw6BO8KrueUw934DgSZIDm8pYYYgYGllKl0k6pNzuOqYeohy6w==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.47.0",
+        "@aws-sdk/config-resolver": "3.47.0",
+        "@aws-sdk/credential-provider-node": "3.47.0",
+        "@aws-sdk/fetch-http-handler": "3.47.0",
+        "@aws-sdk/hash-node": "3.47.0",
+        "@aws-sdk/invalid-dependency": "3.47.0",
+        "@aws-sdk/middleware-content-length": "3.47.0",
+        "@aws-sdk/middleware-host-header": "3.47.0",
+        "@aws-sdk/middleware-logger": "3.47.0",
+        "@aws-sdk/middleware-retry": "3.47.0",
+        "@aws-sdk/middleware-serde": "3.47.0",
+        "@aws-sdk/middleware-signing": "3.47.0",
+        "@aws-sdk/middleware-stack": "3.47.0",
+        "@aws-sdk/middleware-user-agent": "3.47.0",
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/node-http-handler": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/smithy-client": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/url-parser": "3.47.0",
+        "@aws-sdk/util-base64-browser": "3.47.0",
+        "@aws-sdk/util-base64-node": "3.47.0",
+        "@aws-sdk/util-body-length-browser": "3.47.0",
+        "@aws-sdk/util-body-length-node": "3.47.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.47.0",
+        "@aws-sdk/util-defaults-mode-node": "3.47.0",
+        "@aws-sdk/util-user-agent-browser": "3.47.0",
+        "@aws-sdk/util-user-agent-node": "3.47.0",
+        "@aws-sdk/util-utf8-browser": "3.47.0",
+        "@aws-sdk/util-utf8-node": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.47.0.tgz",
+      "integrity": "sha512-akkyVuElsSiCCUSGIIZjIhSaPg6hjebffjtcfn1yNHTrZchKw02htUpl4BJUpZE2patFABIDhaW4UK3xPtklAQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.47.0",
+        "@aws-sdk/fetch-http-handler": "3.47.0",
+        "@aws-sdk/hash-node": "3.47.0",
+        "@aws-sdk/invalid-dependency": "3.47.0",
+        "@aws-sdk/middleware-content-length": "3.47.0",
+        "@aws-sdk/middleware-host-header": "3.47.0",
+        "@aws-sdk/middleware-logger": "3.47.0",
+        "@aws-sdk/middleware-retry": "3.47.0",
+        "@aws-sdk/middleware-serde": "3.47.0",
+        "@aws-sdk/middleware-stack": "3.47.0",
+        "@aws-sdk/middleware-user-agent": "3.47.0",
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/node-http-handler": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/smithy-client": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/url-parser": "3.47.0",
+        "@aws-sdk/util-base64-browser": "3.47.0",
+        "@aws-sdk/util-base64-node": "3.47.0",
+        "@aws-sdk/util-body-length-browser": "3.47.0",
+        "@aws-sdk/util-body-length-node": "3.47.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.47.0",
+        "@aws-sdk/util-defaults-mode-node": "3.47.0",
+        "@aws-sdk/util-user-agent-browser": "3.47.0",
+        "@aws-sdk/util-user-agent-node": "3.47.0",
+        "@aws-sdk/util-utf8-browser": "3.47.0",
+        "@aws-sdk/util-utf8-node": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.47.0.tgz",
+      "integrity": "sha512-GVBeDm8XS2nSz2XS8cDJuudb3E4OWk9CCMzftjJBdFNacRx76irSBnerCGgHG1wwoaUD90lUCDbdY/IwVlS4Pg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.47.0",
+        "@aws-sdk/credential-provider-node": "3.47.0",
+        "@aws-sdk/fetch-http-handler": "3.47.0",
+        "@aws-sdk/hash-node": "3.47.0",
+        "@aws-sdk/invalid-dependency": "3.47.0",
+        "@aws-sdk/middleware-content-length": "3.47.0",
+        "@aws-sdk/middleware-host-header": "3.47.0",
+        "@aws-sdk/middleware-logger": "3.47.0",
+        "@aws-sdk/middleware-retry": "3.47.0",
+        "@aws-sdk/middleware-sdk-sts": "3.47.0",
+        "@aws-sdk/middleware-serde": "3.47.0",
+        "@aws-sdk/middleware-signing": "3.47.0",
+        "@aws-sdk/middleware-stack": "3.47.0",
+        "@aws-sdk/middleware-user-agent": "3.47.0",
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/node-http-handler": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/smithy-client": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/url-parser": "3.47.0",
+        "@aws-sdk/util-base64-browser": "3.47.0",
+        "@aws-sdk/util-base64-node": "3.47.0",
+        "@aws-sdk/util-body-length-browser": "3.47.0",
+        "@aws-sdk/util-body-length-node": "3.47.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.47.0",
+        "@aws-sdk/util-defaults-mode-node": "3.47.0",
+        "@aws-sdk/util-user-agent-browser": "3.47.0",
+        "@aws-sdk/util-user-agent-node": "3.47.0",
+        "@aws-sdk/util-utf8-browser": "3.47.0",
+        "@aws-sdk/util-utf8-node": "3.47.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.47.0.tgz",
+      "integrity": "sha512-D3YV/hIVaUOHDVpLCwZGOyjSdQpxOVKnRPWT++kR6W0r5WC9F4tEtVCYwMnFRTVhOH87VvcMG/dkT5J4gTAgtQ==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-config-provider": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.47.0.tgz",
+      "integrity": "sha512-x5FctbVUkr//KbjDm8UFFZ7caEl0O1E3vDOxezzZ4yUX4EraKRuYKO1dZIAGNBbNzSBv5simpqVxIXNuGyK9zw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.47.0.tgz",
+      "integrity": "sha512-GKfl8O/5Ywnn6/0KfsXopXKrGF31MWCBivISAbubN08X5Up7sQoJPAaDZ5xsi389yZ7+fdTCLKwOyrxobIsGLA==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/url-parser": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.47.0.tgz",
+      "integrity": "sha512-h0VWqSdpDYjOMVJRmBXcVFW1+znXMGPmp2fXIg/1dgNkgbdstknFEwUXbgzmrVmE33Wc2UNpQYmnn3lvLUo85Q==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.47.0",
+        "@aws-sdk/credential-provider-imds": "3.47.0",
+        "@aws-sdk/credential-provider-sso": "3.47.0",
+        "@aws-sdk/credential-provider-web-identity": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-credentials": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.47.0.tgz",
+      "integrity": "sha512-38T8CK7aUI7Uca3Wu686c6OAaLCfvmIPteiTyRQDr+GA9ElJo5d6bONc2ICibLzV7OGqgP/a7wPONnGPEe3VzA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.47.0",
+        "@aws-sdk/credential-provider-imds": "3.47.0",
+        "@aws-sdk/credential-provider-ini": "3.47.0",
+        "@aws-sdk/credential-provider-process": "3.47.0",
+        "@aws-sdk/credential-provider-sso": "3.47.0",
+        "@aws-sdk/credential-provider-web-identity": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-credentials": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.47.0.tgz",
+      "integrity": "sha512-uk/u9tCzsgrYx9V6GtGlp6xkbblyF0auofxKIEyr2xIFQAtfa9GhCAP1F9bMbH9LcdF3pYhGI5rT3FCBuBbdmg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-credentials": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.47.0.tgz",
+      "integrity": "sha512-isM2AKsgz/8mWP4mAAZZ0h4dMx2cNXu7mwNVl0XICV0JQlMA2CYcC9UfQ34NtCsZUY+gjhU2A001Ai9yJDispg==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-credentials": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.47.0.tgz",
+      "integrity": "sha512-Tz17aDOuQv/lIRHuc/cbCS902QCpGakcy4MBxDPj1g5ccozrJC7IniS7OB3X4ghberggxx/4raWjNToNqtfobg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.47.0.tgz",
+      "integrity": "sha512-FSQ5qQkHmCNAgjO2E89vV4QAN66EnHK8sTh4eH55UU0+9/h85g0uMTLMovoEN5Jk+h6AmPCbeq9i+HcPJTmWEQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/querystring-builder": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-base64-browser": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.47.0.tgz",
+      "integrity": "sha512-OqLS/WweCBJz4BwO+EPF1yDeDo8YXXavY/vXElX6reb9+xew9TqmHoFSlFSR8GXkPU7SO+YnlOtmikpMz6fExQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-buffer-from": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.47.0.tgz",
+      "integrity": "sha512-D2n0RA0o8WyFqPuwbVks177KasNK0bcJn+Fp6GzopSwSXQctULidm7S9pDS9fQW9TZW8xREeHhEyRgmstKc+PQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.47.0.tgz",
+      "integrity": "sha512-vm3rjUo9EYjLiog3OxGu+f0CdFjTooO2mg5bGb13Xv/2jpg6Z573Skms8nPEaF+ULJWJvobdK+yGw8r4w22cLA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.47.0.tgz",
+      "integrity": "sha512-xLz7BOYpb4rDsxOzyo5v7zPPI1F6vP+S19zpGcBWCg9csIOrbwSTrtwU+yOAfq7ZG+GSVxWnvMEsyqm362VF8Q==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.47.0.tgz",
+      "integrity": "sha512-jkCoH7wHTWo5UduB46e4A71Uj5EKSYf/44Sxf+/PGyOaGW+SbP9nkjdjyWKB5p84WmvhayZLed/qUJgJpTrpGA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.47.0.tgz",
+      "integrity": "sha512-cK1q+43n2jh/j7jTuFIez7u5k56i2YnjP3DRlh12PfiXiA9V39mfdIu59XHERtE+wJlAyHUq1lYix83CMXOWfQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.47.0.tgz",
+      "integrity": "sha512-AHIxtUFNWSLNZjpgR0Jfx+6X78qPJjmyrfv8S5MVW1uURZK14aepV+0JyGBkjFPJVu0yQzcIlvIgKO20e3zQwQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/service-error-classification": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.47.0.tgz",
+      "integrity": "sha512-DbXxMeGmnxjOt6fk2UHuQQmuRILnHr5mj6e3xwiYmkg7ClM2fmP3vy94Q98RgDtpEwlyb6yHCONiWP4iXExoug==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/signature-v4": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.47.0.tgz",
+      "integrity": "sha512-MYJqW9xoq//FHa6A6drZ48Wswy8vuFrnbTsKK45AsIKs8kdscYnlWC8s7ndmYrMoT4235TRi8QgcjLC8WMIu9Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.47.0.tgz",
+      "integrity": "sha512-oDQ93PiP/90Kl7b3AcHLxsHtWNSxTSdYbJRu4mLb31jKobd2GmLc+tz7L8DpKRyv+fkbrf0Lxh/zLAwaaZdNfg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/signature-v4": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.47.0.tgz",
+      "integrity": "sha512-F2iwZMXERLTddIovCa7uQmrKXTu3O/Rbym/xKC51J1hnELoNudzIuNIdUQsnSfSIJBl0pB5najN1O2IHBcO/oQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.47.0.tgz",
+      "integrity": "sha512-L0uYhbzXDXSYkvtSzLhpSqv/Hg0Wlwf0PPdYHqPmNJFrN+rigjxvu32e10lZj8JCsqX/tRlPULQdrn1mOvHeMg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.47.0.tgz",
+      "integrity": "sha512-YLv2CmM8CfedhtrqMhSoEtJenJlWWGCBOvhewXhEPMa+P/PKZ9HxsKdOTC/+lpuWhnD700fG6kFnn2R0kSQE4g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.47.0.tgz",
+      "integrity": "sha512-wZAU3BLLn/mmWR8bYIBdx+gcdwjO1KNNe7C6yXUwvFgClBjCxqR6C32k8CJ3eGiKulGgkBmX8DKGXIdqv0W7kw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/querystring-builder": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.47.0.tgz",
+      "integrity": "sha512-S59dASvUxqepS9jTxoN9YrP1CTioYcbNLdg2VwFNglXNRekOP2sxyvtGxDE3oVc3ZgzEyq8+OWsReONf8Tdy4g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.47.0.tgz",
+      "integrity": "sha512-Oz9iTfuMmpGVB8AGqJ4A1S8OmcAQlM4/f0QLHLp1Kcjnu7H3jysk3B7qWLgqxO7DwKEX4XU8AXohwQv1aXgI8Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.47.0.tgz",
+      "integrity": "sha512-Ou5ipsOZgsMkSnA61Y5xRoOaxHX9vuqBlWL6iAppSonFanj73qrmymUY+AGUznDiUAxCWcvxdnPUIYDm5grwyg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-uri-escape": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.47.0.tgz",
+      "integrity": "sha512-UQlLg7KDHQAQwS4lILE9wht+m3azXrNjWDAHeQqsG8mqCjvSCu5L9t3BBI+EO4dPb9CKa61fjtuzslxvpZdZ3w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.47.0.tgz",
+      "integrity": "sha512-15SEeOb+In/hEiSfEWYQvjuA5NeoWlh1iOt8aX4eQLqqIIr5DWyLsremTeWtNN3rIbJzU7yVHg5cv2xn3MJ8Wg==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.47.0.tgz",
+      "integrity": "sha512-yPl190HEyTNawkaOnGkG4zgY+dlXDvSx/RRMxsYoBycaU7V4dfYlXkVZDFe0hqnxw/s/aN7qKfzvEvRkrd9kcg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.47.0.tgz",
+      "integrity": "sha512-b1JDXaBRNQ9niMz7Hj6XZ2OfDNT8+a+3fP+BxmFlaFPV++Huo1ClpimzFS8KjRBBrFltTOPPJnEfS+M4cBsnEQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-hex-encoding": "3.47.0",
+        "@aws-sdk/util-uri-escape": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.47.0.tgz",
+      "integrity": "sha512-rq1H//VJKopXgRJgso+BdFBD4hrssbFky1BuvXu7orIi8Wp7oS2LogKctqclX7THrXCNT6mzHaxvU6xEOWYUXg==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.47.0.tgz",
+      "integrity": "sha512-ljxyrASkxCsgPXW/jRGGokNtjOql4RbzEl23HEliDmmETlKOrUKVDa2iqhnz5nvqVTc1MgOQv/dr9YBO1LHHIQ==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.47.0.tgz",
+      "integrity": "sha512-BGfyYZgPvcJ+fW5+i29fy9IwG/2R3LYnWyZ85AFbE++8YcMueJhD7Sychh3mUINViCzjUTVC971m56ee9O9QLA==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.47.0.tgz",
+      "integrity": "sha512-mG6mCdWWzxdDNKmF4YAn4LH7DBdPfTH/eN8ZrkEWamx9goaO1odQz7p86bxMFe5qMHSPRMgGpCuQoJurg7E4cg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.47.0.tgz",
+      "integrity": "sha512-r2ym8kSeLR4m18TFM8M3IThkj3i0DvETF/kxPdfa2fHKL7Lq7bfUDJjzr0LmFhdy7iEEcjeLO1hyBklyCke1nQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.47.0.tgz",
+      "integrity": "sha512-1hHX3uXrl/XKYx2dEULDhtBeofQLHQhllUSbtxj/t8HBZtNhwTSXgb0jbZhPvUFCnzL5ag4znYzEyukLLxgwwQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.47.0.tgz",
+      "integrity": "sha512-PGh5179ZEDS9kcUy1M0i5QiNMeVsCseXh152OT6rU/3yb0h9rozefED/DYEnW/UC0eQNDyj0mgEpT9R86e4S2w==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.47.0.tgz",
+      "integrity": "sha512-pANJWhIZ32RuQVwtqf2rqllZngZYW0dgOiDwCMCDjBOuhlrqCVs2cwOvDJp7SS5TUg6dt6powFC7UKRRjFMe1g==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.47.0.tgz",
+      "integrity": "sha512-93JmYEtExWBlFM18yt7CuUCBf7WQGAjDEMuhy2sCmhgu+lRwicSCLkjEUFPUTxOv2QbU3HJV2CSKzpAjFAWrSA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-credentials": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.47.0.tgz",
+      "integrity": "sha512-0I4Azt1C+xWORep3Qq/B6ZYoIL+fPCgqxYL7k3amW5yjkS4T/r0Md6mG41pb9CEHkbIYtQhzfhcUjqb1hNgIvg==",
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.47.0.tgz",
+      "integrity": "sha512-W5ZYzxU23h6F/2vf6H0BJOzV0UVaCzi9l4sN/00m0FfoGMylwSVeJ0dKMwhMAq5o8sdCSRfzHdvAsXj5TjtghQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.47.0.tgz",
+      "integrity": "sha512-WSTXyAp51FaP0IGf2ZKS1iF7IZ+ct0q8qSBDp12frTIdJO2RZDTQftTq+RrOSj20LXnZi5rf0ICUOFJjomWg4w==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.47.0",
+        "@aws-sdk/credential-provider-imds": "3.47.0",
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.47.0.tgz",
+      "integrity": "sha512-94pkobzbyfasUTUOQSWOixo71ohEPGw2FHnTw/vQ28wQYVYJE8NaV2Z4MyeQlsxSvsthsE4D5u5i1uo+WKFzSQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+      "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.47.0.tgz",
+      "integrity": "sha512-4qxKb98t395h7dQWlD0iUMZpTH1JEPWdcNUCZtbVLwXy5lKzJOl4MPMwObdMhruMa9rgMEKwk6btaSzPK12KAw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.47.0.tgz",
+      "integrity": "sha512-T0MHvvdt98aDGjSnW1wZU0rTtsA/6zr8735ZHTF6ObEH8ZQ28RPTtD0eWO5pUWfReU8yQxDXhBhJK41/lOOtSA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.47.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.47.0.tgz",
+      "integrity": "sha512-aGft3RuO8vQyTFMR5tn4WMtjsVMA9WiPx9WCloheieXmlO7gtez9qr51GFYteBQq9lfdiY9PPj4uaOG21efSIg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.47.0.tgz",
+      "integrity": "sha512-qOYj00VqTVyUVb9gndS9yGHB/tRuK7EPGFvnhRh4VEkwVymH8ywyoFntRhWS/hSrrcQp0W35iS+fJPqdQ1nGWg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.47.0.tgz",
+      "integrity": "sha512-zbcF4zYPta/5tsogtRQ99uPyEB2WGaOyybRaS4cGPhtLiRdA/1wcwmld8ctEaCCf4m4wr2Vu6U9v3SnY92V55w==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.47.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -657,6 +1488,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1549,6 +2385,14 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es6-promise": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
@@ -2089,6 +2933,18 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -3363,8 +4219,7 @@
     "node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -3431,6 +4286,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -3514,6 +4377,708 @@
     }
   },
   "dependencies": {
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.47.0.tgz",
+      "integrity": "sha512-6sxt11dVaJT8CzfVsGCV3h2R0LO12fvXsvCZsMsPGtivb4ZgoFK+PO3hs+9xuA3zjMUC7mb6LE2RM8EXKBDjDw==",
+      "requires": {
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/client-sfn": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.47.0.tgz",
+      "integrity": "sha512-AIcEpLMQof5eJuOpo6Rat5RGpkRCLM3WS3O3hw6BO8KrueUw934DgSZIDm8pYYYgYGllKl0k6pNzuOqYeohy6w==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.47.0",
+        "@aws-sdk/config-resolver": "3.47.0",
+        "@aws-sdk/credential-provider-node": "3.47.0",
+        "@aws-sdk/fetch-http-handler": "3.47.0",
+        "@aws-sdk/hash-node": "3.47.0",
+        "@aws-sdk/invalid-dependency": "3.47.0",
+        "@aws-sdk/middleware-content-length": "3.47.0",
+        "@aws-sdk/middleware-host-header": "3.47.0",
+        "@aws-sdk/middleware-logger": "3.47.0",
+        "@aws-sdk/middleware-retry": "3.47.0",
+        "@aws-sdk/middleware-serde": "3.47.0",
+        "@aws-sdk/middleware-signing": "3.47.0",
+        "@aws-sdk/middleware-stack": "3.47.0",
+        "@aws-sdk/middleware-user-agent": "3.47.0",
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/node-http-handler": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/smithy-client": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/url-parser": "3.47.0",
+        "@aws-sdk/util-base64-browser": "3.47.0",
+        "@aws-sdk/util-base64-node": "3.47.0",
+        "@aws-sdk/util-body-length-browser": "3.47.0",
+        "@aws-sdk/util-body-length-node": "3.47.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.47.0",
+        "@aws-sdk/util-defaults-mode-node": "3.47.0",
+        "@aws-sdk/util-user-agent-browser": "3.47.0",
+        "@aws-sdk/util-user-agent-node": "3.47.0",
+        "@aws-sdk/util-utf8-browser": "3.47.0",
+        "@aws-sdk/util-utf8-node": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.47.0.tgz",
+      "integrity": "sha512-akkyVuElsSiCCUSGIIZjIhSaPg6hjebffjtcfn1yNHTrZchKw02htUpl4BJUpZE2patFABIDhaW4UK3xPtklAQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.47.0",
+        "@aws-sdk/fetch-http-handler": "3.47.0",
+        "@aws-sdk/hash-node": "3.47.0",
+        "@aws-sdk/invalid-dependency": "3.47.0",
+        "@aws-sdk/middleware-content-length": "3.47.0",
+        "@aws-sdk/middleware-host-header": "3.47.0",
+        "@aws-sdk/middleware-logger": "3.47.0",
+        "@aws-sdk/middleware-retry": "3.47.0",
+        "@aws-sdk/middleware-serde": "3.47.0",
+        "@aws-sdk/middleware-stack": "3.47.0",
+        "@aws-sdk/middleware-user-agent": "3.47.0",
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/node-http-handler": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/smithy-client": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/url-parser": "3.47.0",
+        "@aws-sdk/util-base64-browser": "3.47.0",
+        "@aws-sdk/util-base64-node": "3.47.0",
+        "@aws-sdk/util-body-length-browser": "3.47.0",
+        "@aws-sdk/util-body-length-node": "3.47.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.47.0",
+        "@aws-sdk/util-defaults-mode-node": "3.47.0",
+        "@aws-sdk/util-user-agent-browser": "3.47.0",
+        "@aws-sdk/util-user-agent-node": "3.47.0",
+        "@aws-sdk/util-utf8-browser": "3.47.0",
+        "@aws-sdk/util-utf8-node": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.47.0.tgz",
+      "integrity": "sha512-GVBeDm8XS2nSz2XS8cDJuudb3E4OWk9CCMzftjJBdFNacRx76irSBnerCGgHG1wwoaUD90lUCDbdY/IwVlS4Pg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.47.0",
+        "@aws-sdk/credential-provider-node": "3.47.0",
+        "@aws-sdk/fetch-http-handler": "3.47.0",
+        "@aws-sdk/hash-node": "3.47.0",
+        "@aws-sdk/invalid-dependency": "3.47.0",
+        "@aws-sdk/middleware-content-length": "3.47.0",
+        "@aws-sdk/middleware-host-header": "3.47.0",
+        "@aws-sdk/middleware-logger": "3.47.0",
+        "@aws-sdk/middleware-retry": "3.47.0",
+        "@aws-sdk/middleware-sdk-sts": "3.47.0",
+        "@aws-sdk/middleware-serde": "3.47.0",
+        "@aws-sdk/middleware-signing": "3.47.0",
+        "@aws-sdk/middleware-stack": "3.47.0",
+        "@aws-sdk/middleware-user-agent": "3.47.0",
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/node-http-handler": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/smithy-client": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/url-parser": "3.47.0",
+        "@aws-sdk/util-base64-browser": "3.47.0",
+        "@aws-sdk/util-base64-node": "3.47.0",
+        "@aws-sdk/util-body-length-browser": "3.47.0",
+        "@aws-sdk/util-body-length-node": "3.47.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.47.0",
+        "@aws-sdk/util-defaults-mode-node": "3.47.0",
+        "@aws-sdk/util-user-agent-browser": "3.47.0",
+        "@aws-sdk/util-user-agent-node": "3.47.0",
+        "@aws-sdk/util-utf8-browser": "3.47.0",
+        "@aws-sdk/util-utf8-node": "3.47.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.47.0.tgz",
+      "integrity": "sha512-D3YV/hIVaUOHDVpLCwZGOyjSdQpxOVKnRPWT++kR6W0r5WC9F4tEtVCYwMnFRTVhOH87VvcMG/dkT5J4gTAgtQ==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-config-provider": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.47.0.tgz",
+      "integrity": "sha512-x5FctbVUkr//KbjDm8UFFZ7caEl0O1E3vDOxezzZ4yUX4EraKRuYKO1dZIAGNBbNzSBv5simpqVxIXNuGyK9zw==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.47.0.tgz",
+      "integrity": "sha512-GKfl8O/5Ywnn6/0KfsXopXKrGF31MWCBivISAbubN08X5Up7sQoJPAaDZ5xsi389yZ7+fdTCLKwOyrxobIsGLA==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/url-parser": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.47.0.tgz",
+      "integrity": "sha512-h0VWqSdpDYjOMVJRmBXcVFW1+znXMGPmp2fXIg/1dgNkgbdstknFEwUXbgzmrVmE33Wc2UNpQYmnn3lvLUo85Q==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.47.0",
+        "@aws-sdk/credential-provider-imds": "3.47.0",
+        "@aws-sdk/credential-provider-sso": "3.47.0",
+        "@aws-sdk/credential-provider-web-identity": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-credentials": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.47.0.tgz",
+      "integrity": "sha512-38T8CK7aUI7Uca3Wu686c6OAaLCfvmIPteiTyRQDr+GA9ElJo5d6bONc2ICibLzV7OGqgP/a7wPONnGPEe3VzA==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.47.0",
+        "@aws-sdk/credential-provider-imds": "3.47.0",
+        "@aws-sdk/credential-provider-ini": "3.47.0",
+        "@aws-sdk/credential-provider-process": "3.47.0",
+        "@aws-sdk/credential-provider-sso": "3.47.0",
+        "@aws-sdk/credential-provider-web-identity": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-credentials": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.47.0.tgz",
+      "integrity": "sha512-uk/u9tCzsgrYx9V6GtGlp6xkbblyF0auofxKIEyr2xIFQAtfa9GhCAP1F9bMbH9LcdF3pYhGI5rT3FCBuBbdmg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-credentials": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.47.0.tgz",
+      "integrity": "sha512-isM2AKsgz/8mWP4mAAZZ0h4dMx2cNXu7mwNVl0XICV0JQlMA2CYcC9UfQ34NtCsZUY+gjhU2A001Ai9yJDispg==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-credentials": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.47.0.tgz",
+      "integrity": "sha512-Tz17aDOuQv/lIRHuc/cbCS902QCpGakcy4MBxDPj1g5ccozrJC7IniS7OB3X4ghberggxx/4raWjNToNqtfobg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.47.0.tgz",
+      "integrity": "sha512-FSQ5qQkHmCNAgjO2E89vV4QAN66EnHK8sTh4eH55UU0+9/h85g0uMTLMovoEN5Jk+h6AmPCbeq9i+HcPJTmWEQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/querystring-builder": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-base64-browser": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.47.0.tgz",
+      "integrity": "sha512-OqLS/WweCBJz4BwO+EPF1yDeDo8YXXavY/vXElX6reb9+xew9TqmHoFSlFSR8GXkPU7SO+YnlOtmikpMz6fExQ==",
+      "requires": {
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-buffer-from": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.47.0.tgz",
+      "integrity": "sha512-D2n0RA0o8WyFqPuwbVks177KasNK0bcJn+Fp6GzopSwSXQctULidm7S9pDS9fQW9TZW8xREeHhEyRgmstKc+PQ==",
+      "requires": {
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.47.0.tgz",
+      "integrity": "sha512-vm3rjUo9EYjLiog3OxGu+f0CdFjTooO2mg5bGb13Xv/2jpg6Z573Skms8nPEaF+ULJWJvobdK+yGw8r4w22cLA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.47.0.tgz",
+      "integrity": "sha512-xLz7BOYpb4rDsxOzyo5v7zPPI1F6vP+S19zpGcBWCg9csIOrbwSTrtwU+yOAfq7ZG+GSVxWnvMEsyqm362VF8Q==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.47.0.tgz",
+      "integrity": "sha512-jkCoH7wHTWo5UduB46e4A71Uj5EKSYf/44Sxf+/PGyOaGW+SbP9nkjdjyWKB5p84WmvhayZLed/qUJgJpTrpGA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.47.0.tgz",
+      "integrity": "sha512-cK1q+43n2jh/j7jTuFIez7u5k56i2YnjP3DRlh12PfiXiA9V39mfdIu59XHERtE+wJlAyHUq1lYix83CMXOWfQ==",
+      "requires": {
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.47.0.tgz",
+      "integrity": "sha512-AHIxtUFNWSLNZjpgR0Jfx+6X78qPJjmyrfv8S5MVW1uURZK14aepV+0JyGBkjFPJVu0yQzcIlvIgKO20e3zQwQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/service-error-classification": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.47.0.tgz",
+      "integrity": "sha512-DbXxMeGmnxjOt6fk2UHuQQmuRILnHr5mj6e3xwiYmkg7ClM2fmP3vy94Q98RgDtpEwlyb6yHCONiWP4iXExoug==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/signature-v4": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.47.0.tgz",
+      "integrity": "sha512-MYJqW9xoq//FHa6A6drZ48Wswy8vuFrnbTsKK45AsIKs8kdscYnlWC8s7ndmYrMoT4235TRi8QgcjLC8WMIu9Q==",
+      "requires": {
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.47.0.tgz",
+      "integrity": "sha512-oDQ93PiP/90Kl7b3AcHLxsHtWNSxTSdYbJRu4mLb31jKobd2GmLc+tz7L8DpKRyv+fkbrf0Lxh/zLAwaaZdNfg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/signature-v4": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.47.0.tgz",
+      "integrity": "sha512-F2iwZMXERLTddIovCa7uQmrKXTu3O/Rbym/xKC51J1hnELoNudzIuNIdUQsnSfSIJBl0pB5najN1O2IHBcO/oQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.47.0.tgz",
+      "integrity": "sha512-L0uYhbzXDXSYkvtSzLhpSqv/Hg0Wlwf0PPdYHqPmNJFrN+rigjxvu32e10lZj8JCsqX/tRlPULQdrn1mOvHeMg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.47.0.tgz",
+      "integrity": "sha512-YLv2CmM8CfedhtrqMhSoEtJenJlWWGCBOvhewXhEPMa+P/PKZ9HxsKdOTC/+lpuWhnD700fG6kFnn2R0kSQE4g==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.47.0.tgz",
+      "integrity": "sha512-wZAU3BLLn/mmWR8bYIBdx+gcdwjO1KNNe7C6yXUwvFgClBjCxqR6C32k8CJ3eGiKulGgkBmX8DKGXIdqv0W7kw==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/querystring-builder": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.47.0.tgz",
+      "integrity": "sha512-S59dASvUxqepS9jTxoN9YrP1CTioYcbNLdg2VwFNglXNRekOP2sxyvtGxDE3oVc3ZgzEyq8+OWsReONf8Tdy4g==",
+      "requires": {
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.47.0.tgz",
+      "integrity": "sha512-Oz9iTfuMmpGVB8AGqJ4A1S8OmcAQlM4/f0QLHLp1Kcjnu7H3jysk3B7qWLgqxO7DwKEX4XU8AXohwQv1aXgI8Q==",
+      "requires": {
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.47.0.tgz",
+      "integrity": "sha512-Ou5ipsOZgsMkSnA61Y5xRoOaxHX9vuqBlWL6iAppSonFanj73qrmymUY+AGUznDiUAxCWcvxdnPUIYDm5grwyg==",
+      "requires": {
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-uri-escape": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.47.0.tgz",
+      "integrity": "sha512-UQlLg7KDHQAQwS4lILE9wht+m3azXrNjWDAHeQqsG8mqCjvSCu5L9t3BBI+EO4dPb9CKa61fjtuzslxvpZdZ3w==",
+      "requires": {
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.47.0.tgz",
+      "integrity": "sha512-15SEeOb+In/hEiSfEWYQvjuA5NeoWlh1iOt8aX4eQLqqIIr5DWyLsremTeWtNN3rIbJzU7yVHg5cv2xn3MJ8Wg=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.47.0.tgz",
+      "integrity": "sha512-yPl190HEyTNawkaOnGkG4zgY+dlXDvSx/RRMxsYoBycaU7V4dfYlXkVZDFe0hqnxw/s/aN7qKfzvEvRkrd9kcg==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.47.0.tgz",
+      "integrity": "sha512-b1JDXaBRNQ9niMz7Hj6XZ2OfDNT8+a+3fP+BxmFlaFPV++Huo1ClpimzFS8KjRBBrFltTOPPJnEfS+M4cBsnEQ==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-hex-encoding": "3.47.0",
+        "@aws-sdk/util-uri-escape": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.47.0.tgz",
+      "integrity": "sha512-rq1H//VJKopXgRJgso+BdFBD4hrssbFky1BuvXu7orIi8Wp7oS2LogKctqclX7THrXCNT6mzHaxvU6xEOWYUXg==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.47.0.tgz",
+      "integrity": "sha512-ljxyrASkxCsgPXW/jRGGokNtjOql4RbzEl23HEliDmmETlKOrUKVDa2iqhnz5nvqVTc1MgOQv/dr9YBO1LHHIQ=="
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.47.0.tgz",
+      "integrity": "sha512-BGfyYZgPvcJ+fW5+i29fy9IwG/2R3LYnWyZ85AFbE++8YcMueJhD7Sychh3mUINViCzjUTVC971m56ee9O9QLA==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.47.0.tgz",
+      "integrity": "sha512-mG6mCdWWzxdDNKmF4YAn4LH7DBdPfTH/eN8ZrkEWamx9goaO1odQz7p86bxMFe5qMHSPRMgGpCuQoJurg7E4cg==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.47.0.tgz",
+      "integrity": "sha512-r2ym8kSeLR4m18TFM8M3IThkj3i0DvETF/kxPdfa2fHKL7Lq7bfUDJjzr0LmFhdy7iEEcjeLO1hyBklyCke1nQ==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.47.0.tgz",
+      "integrity": "sha512-1hHX3uXrl/XKYx2dEULDhtBeofQLHQhllUSbtxj/t8HBZtNhwTSXgb0jbZhPvUFCnzL5ag4znYzEyukLLxgwwQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.47.0.tgz",
+      "integrity": "sha512-PGh5179ZEDS9kcUy1M0i5QiNMeVsCseXh152OT6rU/3yb0h9rozefED/DYEnW/UC0eQNDyj0mgEpT9R86e4S2w==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.47.0.tgz",
+      "integrity": "sha512-pANJWhIZ32RuQVwtqf2rqllZngZYW0dgOiDwCMCDjBOuhlrqCVs2cwOvDJp7SS5TUg6dt6powFC7UKRRjFMe1g==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.47.0.tgz",
+      "integrity": "sha512-93JmYEtExWBlFM18yt7CuUCBf7WQGAjDEMuhy2sCmhgu+lRwicSCLkjEUFPUTxOv2QbU3HJV2CSKzpAjFAWrSA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-credentials": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.47.0.tgz",
+      "integrity": "sha512-0I4Azt1C+xWORep3Qq/B6ZYoIL+fPCgqxYL7k3amW5yjkS4T/r0Md6mG41pb9CEHkbIYtQhzfhcUjqb1hNgIvg==",
+      "requires": {
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.47.0.tgz",
+      "integrity": "sha512-W5ZYzxU23h6F/2vf6H0BJOzV0UVaCzi9l4sN/00m0FfoGMylwSVeJ0dKMwhMAq5o8sdCSRfzHdvAsXj5TjtghQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.47.0.tgz",
+      "integrity": "sha512-WSTXyAp51FaP0IGf2ZKS1iF7IZ+ct0q8qSBDp12frTIdJO2RZDTQftTq+RrOSj20LXnZi5rf0ICUOFJjomWg4w==",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.47.0",
+        "@aws-sdk/credential-provider-imds": "3.47.0",
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.47.0.tgz",
+      "integrity": "sha512-94pkobzbyfasUTUOQSWOixo71ohEPGw2FHnTw/vQ28wQYVYJE8NaV2Z4MyeQlsxSvsthsE4D5u5i1uo+WKFzSQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+      "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.47.0.tgz",
+      "integrity": "sha512-4qxKb98t395h7dQWlD0iUMZpTH1JEPWdcNUCZtbVLwXy5lKzJOl4MPMwObdMhruMa9rgMEKwk6btaSzPK12KAw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.47.0.tgz",
+      "integrity": "sha512-T0MHvvdt98aDGjSnW1wZU0rTtsA/6zr8735ZHTF6ObEH8ZQ28RPTtD0eWO5pUWfReU8yQxDXhBhJK41/lOOtSA==",
+      "requires": {
+        "@aws-sdk/types": "3.47.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.47.0.tgz",
+      "integrity": "sha512-aGft3RuO8vQyTFMR5tn4WMtjsVMA9WiPx9WCloheieXmlO7gtez9qr51GFYteBQq9lfdiY9PPj4uaOG21efSIg==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.47.0.tgz",
+      "integrity": "sha512-qOYj00VqTVyUVb9gndS9yGHB/tRuK7EPGFvnhRh4VEkwVymH8ywyoFntRhWS/hSrrcQp0W35iS+fJPqdQ1nGWg==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.47.0.tgz",
+      "integrity": "sha512-zbcF4zYPta/5tsogtRQ99uPyEB2WGaOyybRaS4cGPhtLiRdA/1wcwmld8ctEaCCf4m4wr2Vu6U9v3SnY92V55w==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -3966,6 +5531,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -4690,6 +6260,11 @@
         "ansi-colors": "^4.1.1"
       }
     },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
     "es6-promise": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
@@ -5056,6 +6631,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -5972,8 +7552,7 @@
     "tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -6021,6 +7600,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "type": "module",
   "dependencies": {
+    "@aws-sdk/client-sfn": "^3.47.0",
     "@types/mermaid": "^8.2.7",
     "mermaid": "^8.13.9"
   }

--- a/src/routes/get/[arn].ts
+++ b/src/routes/get/[arn].ts
@@ -1,18 +1,18 @@
 import type { RequestHandler } from '@sveltejs/kit/types/endpoint';
-import { execSync } from 'child_process';
+import { SFN } from '@aws-sdk/client-sfn';
+
+const sfn = new SFN({
+	endpoint: process.env.AWS_ENDPOINT ?? 'http://localhost:8083'
+});
 
 export const get: RequestHandler = async ({ params }) => {
 	const arn = params.arn;
-	const definition = execSync(
-		`aws stepfunctions --endpoint http://localhost:8083 --output json describe-state-machine --state-machine-arn ${arn}`
-	);
-	const executions = execSync(
-		`aws stepfunctions --endpoint http://localhost:8083 --output json list-executions --state-machine-arn ${arn}`
-	);
+	const definition = await sfn.describeStateMachine({ stateMachineArn: arn });
+	const executions = await sfn.listExecutions({ stateMachineArn: arn });
 	return {
 		body: {
-			definition: JSON.parse(definition.toString()),
-			executions: JSON.parse(executions.toString())
+			definition,
+			executions
 		}
 	};
 };


### PR DESCRIPTION
Replaces AWS CLI calls with JS SDK calls, adds optional and as-of-yet undocumented `AWS_ENDPOINT` environment variable to make that somewhat more configurable. Theoretically these calls could happen on the client side, but on the server side they do have access to the auth environment. Probably should centralize the SFN initialization in an API directory.