### PR TITLE
add AWS_ENDPOINT support for list

### DIFF
--- a/src/routes/list.ts
+++ b/src/routes/list.ts
@@ -3,7 +3,7 @@ import { execSync } from 'child_process';
 
 export const get: RequestHandler = async () => {
 	const output = execSync(
-		'aws stepfunctions --endpoint http://localhost:8083 --output json list-state-machines'
+		`aws stepfunctions --endpoint  ${process.env.AWS_ENDPOINT ?? 'http://localhost:8083'} --output json list-state-machines`
 	);
 	return {
 		body: output


### PR DESCRIPTION
tweak to use the same env var to allow endpoint override - 

eg AWS_ENDPOINT=https://states.eu-west-1.amazonaws.com/ npm run dev

for non-local, region endpoint